### PR TITLE
7 - add support to noodle through destructured assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "find": "^0.2.4",
+    "jscodeshift-helper": "^1.1.0",
     "mocha": "^2.4.5"
   }
 }

--- a/test/fixtures/destructured.output.js
+++ b/test/fixtures/destructured.output.js
@@ -3,6 +3,7 @@ import ReactNative from 'react-native';
 const {
   Component,
 } = React;
+
 const {
   View,
   Text,

--- a/test/index.js
+++ b/test/index.js
@@ -48,8 +48,10 @@ Object.keys(pairs).map(inputFilePath => {
   const expected = fs.readFileSync(outputFilePath, 'utf8');
 
   if (transformed.trim() !== expected.trim()) {
-    console.log('expected\n', expected);
-    console.log('actual\n', transformed);
+    console.log('\nexpected\n');
+    console.log(expected);
+    console.log('\nactual\n');
+    console.log(transformed);
     throw new Error('result did not match expected output');
   }
 });


### PR DESCRIPTION
This fixes issue #7 .

* identifies local name of 'react-native' import
* finds places where destructuring is used against local name
* splits apart 'react-native' and 'react' properties
* adds another import for 'react-native' if needed after transform